### PR TITLE
Remove warmUpSolverJIT precompile

### DIFF
--- a/src/Caesar.jl
+++ b/src/Caesar.jl
@@ -106,7 +106,7 @@ include("Deprecated.jl")
 
 @compile_workload begin
   # In here put "toy workloads" that exercise the code you want to precompile
-  warmUpSolverJIT()
+  # warmUpSolverJIT()
 end
 
 end


### PR DESCRIPTION
@dehann, can we remove `warmUpSolverJIT` as it should be precompiled with RoME.